### PR TITLE
Modify delete question api endpoint to use database

### DIFF
--- a/server/helpers/queries.js
+++ b/server/helpers/queries.js
@@ -78,6 +78,17 @@ const questionQueries = {
       values: [question, userId],
     };
   },
+  /**
+   * Delete question query function
+   * @param {number} id Question id
+   * @returns {object} Delete Question query object
+   */
+  deleteQuestion(id) {
+    return {
+      text: 'DELETE FROM questions WHERE id = $1 RETURNING question;',
+      values: [id],
+    };
+  },
 };
 
 const answerQueries = {

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -17,9 +17,6 @@ const validator = {
     params: {
       id: numJoi,
     },
-    body: {
-      userId: numJoi,
-    },
   }),
   validatePostAnswer: validate({
     params: {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,7 +18,7 @@ router.get('/questions', Question.getQuestions);
 router.get('/questions/:id', validator.validateId, Question.getQuestion);
 
 router.post('/questions/', auth.verifyToken, validator.validateQuestion, Question.postQuestion);
-router.delete('/questions/:id', validator.validateDelete, Question.deleteQuestion);
+router.delete('/questions/:id', auth.verifyToken, validator.validateDelete, Question.deleteQuestion);
 
 router.post('/questions/:id/answers/', validator.validatePostAnswer, Answer.postAnswer);
 router.post('/questions/:questionId/answers/:answerId', validator.validateAcceptAnswer, Answer.acceptAnswer);

--- a/server/test/controller-test/question-ctrl.test.js
+++ b/server/test/controller-test/question-ctrl.test.js
@@ -7,6 +7,8 @@ import app from '../../../app';
 chai.use(chaiHttp);
 const { expect } = chai;
 
+let userToken;
+
 describe('GET api/v1/questions', () => {
   it('should return response status 200', (done) => {
     chai.request(app)
@@ -75,7 +77,6 @@ describe('GET api/v1/questions/:id', () => {
 });
 
 describe('POST api/v1/questions', () => {
-  let userToken;
   before((done) => {
     chai.request(app)
       .post('/api/v1/auth/login')
@@ -111,23 +112,24 @@ describe('POST api/v1/questions', () => {
 });
 
 describe('DELETE api/v1/question/:id', () => {
-  it('should return status 404 if user does not exist', (done) => {
+  before((done) => {
     chai.request(app)
-      .del('/api/v1/questions/1')
-      .send({ userId: 34 })
+      .post('/api/v1/auth/login')
+      .send({
+        email: 'garry.doe@gmailcom',
+        password: 'password',
+      })
       .end((err, res) => {
         if (err) done(err);
-        expect(res).to.have.status(404);
-        expect(res.body).to.have.keys('status', 'message');
-        expect(res.body.message).to.deep.equals('this user does not exist');
+        userToken = res.body.token;
         done();
       });
   });
 
   it('should return status 403 if unauthorized', (done) => {
     chai.request(app)
-      .del('/api/v1/questions/4')
-      .send({ userId: 4 })
+      .del('/api/v1/questions/3')
+      .set('Authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(403);
@@ -140,7 +142,7 @@ describe('DELETE api/v1/question/:id', () => {
   it('should return status 404 if question does not exist', (done) => {
     chai.request(app)
       .del('/api/v1/questions/20')
-      .send({ userId: 4 })
+      .set('Authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(404);
@@ -152,21 +154,21 @@ describe('DELETE api/v1/question/:id', () => {
 
   it('should return the deleted question', (done) => {
     chai.request(app)
-      .del('/api/v1/questions/6')
-      .send({ userId: 2 })
+      .del('/api/v1/questions/5')
+      .set('Authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(200);
         expect(res.body.status).to.deep.equals('success');
         expect(res.body.message).to.deep.equals('your question has been deleted');
-        expect(res.body).to.have.property('question');
+        expect(res.body).to.have.property('deletedQuestion');
         done();
       });
   });
   it('should return a validation error for wrong input', (done) => {
     chai.request(app)
       .del('/api/v1/questions/o')
-      .send({ userId: 2 })
+      .set('Authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(400);


### PR DESCRIPTION
#### What does this PR do?
Modify api endpoint **DELETE** `api/v1/questions/:id` to use data from database.

#### Description of Task to be completed?
- Write sql queries to delete question from database.
- Refactor tests to use database

#### How should this be manually tested?
* Clone the repo using `git clone https://github.com/PriscillaSam/Stackoverflow-Lite.git`.
* run `git checkout ft-delete-question-160021517`.
* run `npm install` and `npm start`.
* setup postgresql and add a .env file to the root of the folder. Add your database details as specified in the config/config.js file.
* Open up Postman and login `localhost:3000/api/v1/auth/login`. After login is successful, get token and set in Authorization header. Test **DELETE** `localhost:3000/api/v1/questions/:id`.

**sample login details**
```gherkin
{
   email: "jane.doe@gmail.com",
   password: "password"
}
questionid = 5
```
#### Any background context you want to provide?
None.

#### What are the relevant pivotal tracker stories?
#160021517